### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:12.16.2-buster-slim
+
+EXPOSE 80
+EXPOSE 443
+
+RUN apt-get update && apt-get -y install git libnss3-tools
+
+RUN git clone https://github.com/alfonsomunozpomer/site.js.git
+WORKDIR /site.js
+RUN git checkout docker
+RUN npm install && npm install nexe@3.3.7 --save-dev
+RUN npm run build && cp dist/release/linux/`ls -1t dist/release/linux | head -1`/site /usr/local/bin
+
+VOLUME /site.js/dist
+VOLUME /var/www/html
+
+ENTRYPOINT ["site"]
+CMD ["serve", "/var/www/html", "--docker"]

--- a/bin/commands/serve.js
+++ b/bin/commands/serve.js
@@ -20,6 +20,7 @@ const SYNC_TO = 'sync-to'
 const SYNC_FROM = 'sync-from'
 const LIVE_SYNC = 'live-sync'
 const SYNC_FOLDER_AND_CONTENTS = 'sync-folder-and-contents'
+const DOCKER = 'docker'
 
 // This will only show errors in the access log (HTTP response codes 4xx and 5xx).
 const ACCESS_LOG_ERRORS_ONLY = 'access-log-errors-only'
@@ -145,6 +146,9 @@ function serve (args) {
   const syncRequested = args.named[SYNC_TO] !== undefined
   const liveSync = args.named[LIVE_SYNC]
 
+  // Is Site.js running in a Docker container?
+  const docker = args.named[DOCKER]
+
   //
   // Handle initial sync setup-related tasks.
   //
@@ -186,7 +190,7 @@ function serve (args) {
 
   // Ensure privileged ports are disabled on Linux machines.
   // For details, see: https://source.small-tech.org/site.js/app/-/issues/169
-  ensure.privilegedPortsAreDisabled()
+  ensure.privilegedPortsAreDisabled(docker)
 
   // Start a server and also sync if requested.
   tcpPortUsed.check(port)

--- a/bin/lib/Help.js
+++ b/bin/lib/Help.js
@@ -82,6 +82,8 @@ class Help {
     const optionAccessLogErrorsOnly = option('access-log-errors-only')
     const optionAccessLogDisable = option('access-log-disable')
 
+    const optionDocker = option('docker')
+
     // Black right-pointing triangle (U+25B6)
     // (There are several similar unicode gylphs but this is the one that works well across
     // Linux, macOS, and Windows).
@@ -150,6 +152,7 @@ class Help {
     ${optionSyncFrom}\t\t\t\tThe folder to sync from.
     ${optionLiveSync}\t\t\t\tWatch for changes and live sync them to a remote server.
     ${optionSyncFolderAndContents}\t\tSync local folder and contents (default is to sync the folder’s contents only).
+    ${optionDocker}\t\t\t\tSet when running in a Docker container (does not disable privileged ports).
 
     ${ this.systemdExists ? `For ${commandEnable} command:
 

--- a/bin/lib/ensure.js
+++ b/bin/lib/ensure.js
@@ -122,8 +122,8 @@ class Ensure {
   // execute, we carry it out every time.
   //
   // For more details, see: https://source.small-tech.org/site.js/app/-/issues/169
-  privilegedPortsAreDisabled () {
-    if (os.platform() === 'linux') {
+  privilegedPortsAreDisabled (docker) {
+    if (os.platform() === 'linux' && !docker) {
       try {
         Site.logAppNameAndVersion()
 


### PR DESCRIPTION
To spin up a container just do:
```bash
docker build -t sitejs .
docker run -p 80:80 -p 443:443 sitejs
```

Since [running `sysctl` within a Docker container is not allowed](https://docs.docker.com/engine/reference/commandline/run/#configure-namespaced-kernel-parameters-sysctls-at-runtime) I added a flag for the `serve` command to skip disabling privileged ports on Linux via `sudo sysctl ...`. I haven’t added documentation of this flag in README.md since I’m not sure how you’d like to handle this.

Regarding the Dockerfile itself, I first had in mind building Site.js in the host machine and then add it to the container via `COPY`. However, on my first go at it, running Site.js in the container complained about libc versions, so I decided to better build the app in the image. The biggest downside of this method is that the resulting image is a whopping 1.2 GB. Another option could be to have two containers, one that builds the app and produces the executable `site` and then copy it to a second container. I’ve tried it and the resulting image is ~200 MB. The downside is that the whole process isn’t self-contained in a single step.

To build Site.js in the container I had to replace your self-hosted patched version of Nexe with version 3.3.7. If I didn’t, running `npm install` would produce a `node_modules/nexe` directory which missed a required `lib` directory. This didn’t happen outside the container, so it’s really puzzling and if somebody has enough free time to investigate what’s going on I’d love to hear why.

A limitation is that within Docker you can’t run the command `enable`, again due to Docker’s limitations (no `systemd` or `systemctl`). However, I think that’s fine and running `serve` fits with the Docker/container philosophy of one container, one process.

By default the resulting container runs `site serve /var/www/html --docker` but you can pass any command you like, e.g.:
```bash
docker build -t sitejs .
docker run sitejs help
```

What I’ve noticed is that Firefox (or any other browser) won’t trust the certificates coming from the container. I’ve very limited knowledge about HTTPS/SSL so this is something that currently I haven’t got the time to look into. Without any arguments `curl` will fail:
```bash
$ curl 'https://localhost'
curl: (60) SSL certificate problem: self signed certificate in certificate chain
More details here: https://curl.haxx.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```

But:
```bash
$ curl -k 'https://localhost'
<!doctype html><html lang="en" style="font-family: sans-serif; background-color: #eae7e1"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>Error 404: Not found</title></head><body style="display: grid; align-items: center; justify-content: center; height: 100vh; vertical-align: top; margin: 0;"><main><h1 style="font-size: 16vw; color: black; text-align:center; line-height: 0.25">4🤭4</h1><p style="font-size: 4vw; text-align: center; padding-left: 2vw; padding-right: 2vw;"><span>Could not find</span> <span style="color: grey;">/</span></p></main>  <script src="/instant/client/bundle.js"></script>
```

@aral Let me know your thoughts. No worries if this stays on hold, but solving the SSL certificates issue would be at least necessary in order to merge IMO.